### PR TITLE
[Fix] isCacheFirst not working

### DIFF
--- a/lib/src/geo_collection_reference.dart
+++ b/lib/src/geo_collection_reference.dart
@@ -299,17 +299,15 @@ class GeoCollectionReference<T> {
           geohash: geohash,
           queryBuilder: queryBuilder,
         );
-        try {
-          querySnapshot = await query.get(
-            GetOptions(
-              source: isCacheFirst ? Source.cache : Source.serverAndCache,
-            ),
-          );
-        } on FirebaseException {
-          if (!isCacheFirst) {
-            rethrow;
-          }
-          querySnapshot = await query.get();
+
+        querySnapshot = await query.get(
+          GetOptions(
+            source: isCacheFirst ? Source.cache : Source.serverAndCache,
+          ),
+        );
+        if (querySnapshot.docs.isEmpty && isCacheFirst) {
+          querySnapshot =
+              await query.get(const GetOptions(source: Source.server));
         }
         return querySnapshot.docs;
       },


### PR DESCRIPTION
In my previous PR I've implemented the `isCacheFirst` functionality. However, `Query<T>.get()` does not throw an error if no result matches the query, contradictory to my expectations. As the documentation says for `Source.cache`

> Causes Firestore to immediately return a value from the cache, ignoring the server completely (implying that the returned value may be stale with respect to the value on the server). If there is no data in the cache to satisfy the get call, [DocumentReference.get] will throw a [FirebaseException] and [Query.get] will return an empty [QuerySnapshotPlatform] with no documents.

I decided not to go for exceptions, and instead check if cache returns an empty result, then it attempts to fetch data from server.

I'm sorry for the inconvenience, I didn't test the code well. This time I battle-tested it and even if I search a relatively small area and get some data, expanding the area results in new data being fetched anyways. 
